### PR TITLE
Refactor Form Listener

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,5 +25,6 @@ module.exports = {
     "BASE_URL": true,
     "ROOT_PATH": true,
     "IS_SCREENSHOTTING": true,
+    "SIGNUP_ENDPOINT": true,
   }
 }

--- a/README.md
+++ b/README.md
@@ -186,3 +186,4 @@ Key Name | Description
 `IS_SCREENSHOTTING` | Used to control some run-time settings when generating screenshots for share images. In development this can be left blank.
 `GA_TRACKING_ID` | The GA ID for pageviews
 `AWS_CLOUDFRONT` | Distribution ID. Used by Circle CI to invalidate the cloud front cache on deploy
+`SIGNUP_ENDPOINT` | The zapier webhook endpoint to submit emails

--- a/src/js/address-form.js
+++ b/src/js/address-form.js
@@ -44,8 +44,8 @@ export function bindAddressFormEvents(form, errors, multiples) {
 
   $(form).addEventListener('submit', e => {
     $(form).classList.add('loading');
-    $(errors).innerHTML = '';
-    $(multiples).innerHTML = '';
+    $(errors).textContent = '';
+    $(multiples).textContent = '';
     e.preventDefault();
     let address = $('.address-form__input').value;
     lookupAddress(address, geocoder).then(result => {
@@ -53,31 +53,31 @@ export function bindAddressFormEvents(form, errors, multiples) {
         Turnout.router.transitionTo('district', district);
       }).catch(error => {
         if (error.error === 'no data') {
-          $(errors).innerHTML = error.message;
+          $(errors).textContent = error.message;
         }
       });
       $(form).classList.remove('loading');
     }).catch(error => {
       if(error.error === 'multiple locations') {
-        $(multiples).innerHTML = '';
+        $(multiples).textContent = '';
         let question = document.createElement('p');
-        question.innerText = 'Did you mean...';
+        question.textContent = 'Did you mean...';
         $(multiples).appendChild(question);
         error.results.forEach(result => {
           getDistrict(result.geometry.location.lat(), result.geometry.location.lng())
           .then(district => {
             let link = document.createElement('a');
-            link.innerText = result.formatted_address;
+            link.textContent = result.formatted_address;
             link.href = `${ROOT_PATH}${district.elect_dist}`;
             $(multiples).appendChild(link);
           });
         });
       } else if (error.error === 'out of bounds') {
-        $(errors).innerText = 'Please use an address in the 5 boroughs';
+        $(errors).textContent = 'Please use an address in the 5 boroughs';
       } else if (error.error === 'no results') {
-        $(errors).innerText = 'Invalid Address';
+        $(errors).textContent = 'Invalid Address';
       } else {
-        $(errors).innerText = `Something unexpected occurred. Got status: ${error.error}`;
+        $(errors).textContent = `Something unexpected occurred. Got status: ${error.error}`;
       }
       $(form).classList.remove('loading');
     });

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -26,7 +26,25 @@ const IndexRoute = {
     insertTemplate($('main'), MainTemplate({
       assetPath: ROOT_PATH,
     }));
-    bindAddressFormEvents('.address-form__form','.address-form__errors','.address-form__multiples');
+    bindAddressFormEvents({
+      form: '.address-form__form',
+      errors: '.address-form__errors',
+      multiples: '.address-form__multiples',
+      fields: [{
+        name: 'address',
+        selector: '#address-form__address-input',
+        message: 'Please enter an address.',
+      }, {
+        name: 'email',
+        selector: '#address-form__email-input',
+        message: 'Please enter an email.',
+      }, {
+        name: 'legal',
+        selector: '#legal',
+        message: 'Please agree to the terms',
+        validation: el => el.checked,
+      }]
+    });
 
     gtag('config', GA_TRACKING_ID, {
       page_title: 'Does Your Block Vote?',
@@ -83,7 +101,30 @@ const DistrictRoute = {
         ...district,
         assetPath: ROOT_PATH,
       }));
-      bindAddressFormEvents('.address-form__form','.address-form__errors','.address-form__multiples');
+      bindAddressFormEvents({
+        form: '#address-form',
+        errors: '#address-errors',
+        multiples: '.address-form__multiples',
+        fields: [{
+          name: 'address',
+          selector: '#address-form__address-input',
+          message: 'Please enter an address.',
+        }]
+      });
+      bindAddressFormEvents({
+        form: '#email-form',
+        errors: '#email-errors',
+        fields: [{
+          name: 'email',
+          selector: '#address-form__email-input',
+          message: 'Please enter an email.',
+        }, {
+          name: 'legal',
+          selector: '#legal',
+          message: 'Please agree to the terms',
+          validation: el => el.checked,
+        }]
+      });
     });
   }
 };

--- a/src/js/templates/district-details.hbs
+++ b/src/js/templates/district-details.hbs
@@ -39,17 +39,17 @@
   </div>
 
 
-  <form class="address-form__form">
+  <form class="address-form__form address-form__form--oneline" id="address-form">
     <label class="address-form__label" for="address-form__input">View A Different Address</label>
     <div class="address-form__input-wrapper">
-      <input id="address-form__input" class="address-form__input" placeholder="123 Broadway, New York, NY">
+      <input id="address-form__address-input" class="address-form__input" placeholder="123 Broadway, New York, NY">
       <button type="submit" id="address-form__button" class="address-form__button"><img class="address-form__button-image" alt="Submit."
   src="{{assetPath}}i/arrow_right@2x.png" width=23 height=16
   srcset="{{assetPath}}i/arrow_right.png 1x,
           {{assetPath}}i/arrow_right@2x.png 2x,
           {{assetPath}}i/arrow_right@3x.png 3x"></button>
     </div>
-    <div class="address-form__errors"></div>
+    <div class="address-form__errors" id="address-errors"></div>
     <div class="address-form__multiples"></div>
   </form>
 
@@ -58,27 +58,25 @@
   <ol class="extra-credit__list">
     <li class="extra-credit__list-item"><b>Share your block&apos;s grade</b> on social media with a messaging encouraging your neighbors to vote on Tuesday, November 6.</li>
     <li class="extra-credit__list-item"><b>Submit your email</b> and we'll send you an email after the general election showing if your block's turnout improved, along with more tips to turn out voters if it didn't.</li>
-    <form action="https://nypublicradio.us5.list-manage.com/subscribe/post?u=4109fdd323aaac7078eadaa8f&amp;id=9f4c9b9202" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate disabled>
-      <div id="mc_embed_signup_scroll">
+    <form class="address-form__form address-form__form--oneline" id="email-form">
+      <div class="address-form__input-wrapper">
+        <input id="address-form__email-input" class="address-form__input" placeholder="You@Email.com">
+        <button type="submit" id="address-form__button" class="address-form__button"><img class="address-form__button-image" alt="Submit."
+    src="{{assetPath}}i/arrow_right@2x.png" width=23 height=16
+    srcset="{{assetPath}}i/arrow_right.png 1x,
+            {{assetPath}}i/arrow_right@2x.png 2x,
+            {{assetPath}}i/arrow_right@3x.png 3x"></button>
+      </div>
 
-        <div class="email-form__input-wrapper">
-          <input type="email" value="" name="EMAIL" class="required email email-form__input" id="mce-EMAIL" placeholder="you@email.com" aria-label="Email address">
-          <button type="submit" id="mc-embedded-subscribe" class="email-form__button"><img class="email-form__button-image" alt="Submit."
-                                                                                                                            src="{{assetPath}}i/arrow_right@2x.png" width=23 height=16
-                                                                                                                            srcset="{{assetPath}}i/arrow_right.png 1x,
-                                                                                                                            {{assetPath}}i/arrow_right@2x.png 2x,
-                                                                                                                            {{assetPath}}i/arrow_right@3x.png 3x"></button>
-        </div>
-        <input type="hidden" value="{{id}}" name="DISTRICT">
-        <div id="mce-responses" class="clear">
-          <div class="response" id="mce-error-response" style="display:none"></div>
-          <div class="response" id="mce-success-response" style="display:none"></div>
-        </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-        <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_4109fdd323aaac7078eadaa8f_9f4c9b9202" tabindex="-1" value=""></div>
-        <label for="optin" class="email-form__optin">
-          <input type="checkbox" name="optin" id="optin" class="email-form__optin-checkbox">
-          <p class="email-form__optin-message">By submitting your information, you're agreeing to receive communications from New York Public Radio in accordance with our <a href="https://www.wnyc.org/terms/">Terms of Use</a>.</p>
+      <div class="checkbox-wrapper">
+        <input type="checkbox" class="checkbox__input" id="legal">
+        <label for="legal" class="checkbox__label">
+          <div class="checkbox__label-text">
+            By submitting your information, you're agreeing to receive communications from New York Public Radio in accordance with our <a href="https://www.wnyc.org/terms/" target="-_blank">Terms of Use</a>.
+          </div>
         </label>
+      </div>
+      <div class="address-form__errors" id="email-errors"></div>
     </form>
     <li class="extra-credit__list-item"><b>Print out this flier</b> to hand out at your next block party, hang in your window, or slip under doors.</li>
     <li class="extra-credit__list-item"><b>Learn about your local races</b> and all election coverage at our <a href="https://elections.wnyc.org/" target="_blank">Elections Hub</a>, and talk to your neighbors and ask them to vote. Studies show that people who publically commit to voting usually do.</li>

--- a/src/js/templates/main.hbs
+++ b/src/js/templates/main.hbs
@@ -6,15 +6,21 @@ srcset="{{assetPath}}i/gothamist_logo.png 1x,
 <div class="address-form">
   <h1 class="address-form__heading">Does your Block Vote?</h1>
   <p class="subheading address-form__subheading">Voter turnout varies dramatically from one block to another in New York City. Find out if your neighbors vote -- and how to get them to the polls if they don't.</p>
-  <form class="address-form__form">
-    <label class="address-form__label" for="address-form__input">Enter your address below</label>
+  <form class="address-form__form address-form__form--stacked">
+    <label class="address-form__label" for="address-form__input">Enter your address + email below</label>
     <div class="address-form__input-wrapper">
-      <input id="address-form__input" class="address-form__input" placeholder="123 Broadway, New York, NY">
-      <button type="submit" id="address-form__button" class="address-form__button"><img class="address-form__button-image" alt="Submit."
-  src="{{assetPath}}i/arrow_right@2x.png" width=23 height=16
-  srcset="{{assetPath}}i/arrow_right.png 1x,
-          {{assetPath}}i/arrow_right@2x.png 2x,
-          {{assetPath}}i/arrow_right@3x.png 3x"></button>
+      <input id="address-form__address-input" class="address-form__input" placeholder="123 Broadway, New York, NY">
+      <input id="address-form__email-input" class="address-form__input" placeholder="Your@Email.com">
+      <button type="submit" id="address-form__button" class="address-form__button">Submit</button>
+
+      <div class="checkbox-wrapper">
+        <input type="checkbox" class="checkbox__input" id="legal">
+        <label for="legal" class="checkbox__label">
+          <div class="checkbox__label-text">
+            By submitting your information, you're agreeing to receive communications from New York Public Radio in accordance with our <a href="https://www.wnyc.org/terms/" target="-_blank">Terms of Use</a>.
+          </div>
+        </label>
+      </div>
     </div>
     <div class="address-form__errors"></div>
     <div class="address-form__multiples"></div>

--- a/src/scss/_checkbox.scss
+++ b/src/scss/_checkbox.scss
@@ -1,0 +1,55 @@
+.checkbox-wrapper {
+}
+
+.checkbox__input {
+  opacity: 0;
+  position: absolute;
+  left: -9999px;
+}
+
+.checkbox__label {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  cursor: pointer;
+
+  &:before {
+    content: '';
+    display: block;
+    margin-top: 3px;
+    margin-right: 15px;
+    flex-shrink: 0;
+    background-color: white;
+
+    height: 15px;
+    width: 15px;
+    border: 1px solid #ddd;
+  }
+
+  &:after {
+    content: '';
+    position: absolute;
+
+    left: 3px;
+    top: 7px;
+    border-left: 2px solid transparent;
+    border-bottom: 2px solid transparent;
+    width: 10px;
+    height: 5px;
+
+    transform: rotate(-45deg);
+    transition: border-color 125ms ease;
+  }
+}
+
+.checkbox__input:focus + .checkbox__label {
+  &:before {
+    outline: #333 dotted 1px;
+  }
+}
+
+.checkbox__input:checked + .checkbox__label {
+  &:after {
+    border-color: blue;
+  }
+}

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -44,18 +44,65 @@ main {
   margin-bottom: 8px;
   text-align: center;
   display: block;
-  font-size: 14px;
+  font-size: 18px;
   font-weight: 600;
 }
 .address-form__input-wrapper {
+  margin: 0 auto 12px;
+  max-width: 300px;
+}
+
+.address-form__form--oneline .address-form__input-wrapper {
   @include one-line-form;
   margin-bottom: 12px;
 }
+
+.address-form__form--stacked .address-form__input {
+  display: block;
+  color: #333;
+  width: 100%;
+  appearance: none;
+  padding: 12px;
+  background: white;
+  border: 2px solid #ddd;
+  font-size: 14px;
+  line-height: 1.5;
+  margin-bottom: 15px;
+
+  &::placeholder {
+    color: #333;
+  }
+}
+
+.address-form__form--stacked .address-form__button {
+  appearance: none;
+  border: none;
+
+  display: block;
+  width: 100%;
+  color: white;
+  font-family: inherit;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.5;
+
+  background-color: black;
+  padding: 12px;
+
+  margin-bottom: 12px;
+}
+
 .address-form__errors {
   text-align: center;
   color: $red;
   font-weight: 600;
   font-size: 14px;
+
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
 }
 .address-form__multiples {
   text-align: center;
@@ -260,6 +307,16 @@ h1.district-map-title {
   @media screen and (min-width: 800px) {
     display: flex;
     justify-content: space-around;
+  }
+
+  .address-form__form {
+    background: none;
+    padding: 0;
+    margin: 0 0 32px;;
+  }
+
+  .address-form__input-wrapper {
+    max-width: none;
   }
 }
 

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -2,3 +2,4 @@
 @import 'main';
 @import 'map';
 @import 'header';
+@import 'checkbox';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,7 @@ module.exports = {
       BASE_URL: JSON.stringify(BASE_URL),
       IS_SCREENSHOTTING: process.env.IS_SCREENSHOTTING ? true : false,
       GA_TRACKING_ID: JSON.stringify(process.env.GA_TRACKING_ID),
+      SIGNUP_ENDPOINT: JSON.stringify(process.env.SIGNUP_ENDPOINT),
     }),
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, 'src/static/index.html'),


### PR DESCRIPTION
And send emails to zapier endpoint

This makes the form logic slightly more modular so that the different fields can be split up but controlled by calls to the same code.