### PR TITLE
Final visual/copy tweaks

### DIFF
--- a/src/js/templates/district-details.hbs
+++ b/src/js/templates/district-details.hbs
@@ -69,7 +69,7 @@
       </div>
 
       <div class="checkbox-wrapper">
-        <input type="checkbox" class="checkbox__input" id="legal">
+        <input type="checkbox" class="checkbox__input" id="legal" checked>
         <label for="legal" class="checkbox__label">
           <div class="checkbox__label-text">
             By submitting your information, you're agreeing to receive communications from New York Public Radio in accordance with our <a href="https://www.wnyc.org/terms/" target="-_blank">Terms of Use</a>.
@@ -112,8 +112,8 @@
       <div class="response" id="mce-success-response" style="display:none"></div>
     </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
       <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_4109fdd323aaac7078eadaa8f_9f4c9b9202" tabindex="-1" value=""></div>
+      <input type="checkbox" name="optin" id="optin" class="email-form__optin-checkbox" checked>
       <label for="optin" class="email-form__optin">
-        <input type="checkbox" name="optin" id="optin" class="email-form__optin-checkbox">
         <p class="email-form__optin-message">By submitting your information, you're agreeing to receive communications from New York Public Radio in accordance with our <a href="https://www.wnyc.org/terms/">Terms of Use</a>.</p>
       </label>
   </form>

--- a/src/js/templates/district-details.hbs
+++ b/src/js/templates/district-details.hbs
@@ -54,10 +54,10 @@
   </form>
 
 <div class="extra-credit">
-  <h2 class="extra-credit__heading">What You Can Do To Improve Turnout on Your Block</h2>
+  <h2 class="extra-credit__heading">What You Can Do To Improve Turnout On Your Block</h2>
   <ol class="extra-credit__list">
-    <li class="extra-credit__list-item"><b>Share your block&apos;s grade</b> on social media with a messaging encouraging your neighbors to vote on Tuesday, November 6.</li>
-    <li class="extra-credit__list-item"><b>Submit your email</b> and we'll send you an email after the general election showing if your block's turnout improved, along with more tips to turn out voters if it didn't.</li>
+    <li class="extra-credit__list-item"><b>Share your block&apos;s grade</b> on social media with a message encouraging your neighbors to vote on Tuesday, November 6.</li>
+    <li class="extra-credit__list-item"><b>Submit your email</b> to stay informed on elections news, along with tips on how to get involved.</li>
     <form class="address-form__form address-form__form--oneline" id="email-form">
       <div class="address-form__input-wrapper">
         <input id="address-form__email-input" class="address-form__input" placeholder="You@Email.com">
@@ -78,7 +78,7 @@
       </div>
       <div class="address-form__errors" id="email-errors"></div>
     </form>
-    <li class="extra-credit__list-item"><b>Print out this flier</b> to hand out at your next block party, hang in your window, or slip under doors.</li>
+    <li class="extra-credit__list-item"><b>Print this page</b> to hand out at your next block party, hang in your window, or slip under doors.</li>
     <li class="extra-credit__list-item"><b>Learn about your local races</b> and all election coverage at our <a href="https://elections.wnyc.org/" target="_blank">Elections Hub</a>, and talk to your neighbors and ask them to vote. Studies show that people who publically commit to voting usually do.</li>
   </ol>
 </div>

--- a/src/js/templates/district-details.hbs
+++ b/src/js/templates/district-details.hbs
@@ -94,7 +94,7 @@
 <!-- Begin MailChimp Signup Form -->
 <div  id="mc_embed_signup" class="email-updates">
   <h2 class="email-updates__heading"><i class="fas fa-envelope"></i> Get Email Updates</h2>
-  <p class="email-updates__description">Post election, we’ll notify you on how your efforts affected voter turnout- we’re awarding a special prize to the district with the highest turnout, and the district that most improved in rank.</p>
+  <p class="email-updates__description">WNYC and Gothamist are teaming up to offer essential news and analysis in our new newsletter, the Politics Brief. Sign up to receive the Politics Brief by entering your email here.</p>
   <form action="https://nypublicradio.us5.list-manage.com/subscribe/post?u=4109fdd323aaac7078eadaa8f&amp;id=9f4c9b9202" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate disabled>
     <div id="mc_embed_signup_scroll">
 

--- a/src/js/templates/district-details.hbs
+++ b/src/js/templates/district-details.hbs
@@ -29,11 +29,11 @@
       23% city-wide.</b>
     </p>
     <p class="district-ranking__text">Your district ranked #{{boro_rank}} out of
-      {{borough_data_2014.max_rank}} in {{borough}}, where on average
+      #{{borough_data_2014.max_rank}} in {{borough}}, where on average
       {{borough_data_2014.avg_percent}}% of registered voters turned out.
     </p>
-    <p class="district-ranking__text">Comparitavely, your district ranked
-      {{2016_rank}} out of {{borough_data_2016.max_rank}} in the 2016 presidential
+    <p class="district-ranking__text">Comparatively, your district ranked
+      {{2016_rank}} out of {{borough_data_2014.max_rank}} in the 2016 presidential
       election, with {{2016_percent}}% of registered voters casting ballots.
     </p>
   </div>

--- a/src/js/templates/district-map.hbs
+++ b/src/js/templates/district-map.hbs
@@ -1,5 +1,5 @@
 <div class="district-details__eyebrow">
-  <a class="district-details__eyebrow-link">
+  <a class="district-details__eyebrow-link" href="../">
   <img class="gothamist-logo-mini" alt="Gothamist."
   src="{{assetPath}}i/gothamist_logo.png" width=29 height=29
   srcset="{{assetPath}}i/gothamist_logo.png 1x,

--- a/src/js/templates/district-map.hbs
+++ b/src/js/templates/district-map.hbs
@@ -9,7 +9,7 @@
   </a>
 </div>
 
-<h1 class="district-map-title">Election/Assembly District: <span class="election-district" id="election-district">{{ed}}</span>/<span id="assembly-district">{{ad}}</span></h1>
+<h1 class="district-map-title">Election &amp; Assembly District: <span class="election-district" id="election-district">{{ed}}</span>/<span id="assembly-district">{{ad}}</span></h1>
 
 <div class="district-ranking__scores">
   <div class="district-ranking__grade">

--- a/src/js/templates/main.hbs
+++ b/src/js/templates/main.hbs
@@ -18,7 +18,7 @@
       <button type="submit" id="address-form__button" class="address-form__button">Submit</button>
 
       <div class="checkbox-wrapper">
-        <input type="checkbox" class="checkbox__input" id="legal">
+        <input type="checkbox" class="checkbox__input" id="legal" checked>
         <label for="legal" class="checkbox__label">
           <div class="checkbox__label-text">
             By submitting your information, you're agreeing to receive communications from New York Public Radio in accordance with our <a href="https://www.wnyc.org/terms/" target="-_blank">Terms of Use</a>.

--- a/src/js/templates/main.hbs
+++ b/src/js/templates/main.hbs
@@ -9,9 +9,8 @@
 </div>
 <div class="address-form">
   <h1 class="address-form__heading">Does your Block Vote?</h1>
-  <p class="subheading address-form__subheading">Voter turnout varies dramatically from one block to another in New York City. Find out if your neighbors vote -- and how to get them to the polls if they don't.</p>
+  <p class="subheading address-form__subheading">Voter turnout varies dramatically from one block to another in New York City. Enter your address and email below to find out if your neighbors vote—and how to get them to the polls if they don't.</p>
   <form class="address-form__form address-form__form--stacked">
-    <label class="address-form__label" for="address-form__input">Enter your address + email below</label>
     <div class="address-form__input-wrapper">
       <input id="address-form__address-input" class="address-form__input" placeholder="123 Broadway, New York, NY">
       <input id="address-form__email-input" class="address-form__input" placeholder="Your@Email.com">

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -40,3 +40,10 @@ h6 {
   text-align: center;
   margin: 0;
 }
+
+p, li {
+  @media screen and (min-width: 800px) {
+    font-size: 18px;
+    line-height: 27px;
+  }
+}

--- a/src/scss/_checkbox.scss
+++ b/src/scss/_checkbox.scss
@@ -1,13 +1,13 @@
 .checkbox-wrapper {
 }
 
-.checkbox__input {
+.checkbox__input, .email-form__optin-checkbox {
   opacity: 0;
   position: absolute;
   left: -9999px;
 }
 
-.checkbox__label {
+.checkbox__label, .email-form__optin {
   position: relative;
   display: flex;
   align-items: flex-start;
@@ -49,6 +49,18 @@
 }
 
 .checkbox__input:checked + .checkbox__label {
+  &:after {
+    border-color: blue;
+  }
+}
+
+.email-form__optin-checkbox:focus + .email-form__optin {
+  &:before {
+    outline: #333 dotted 1px;
+  }
+}
+
+.email-form__optin-checkbox:checked + .email-form__optin {
   &:after {
     border-color: blue;
   }

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -21,10 +21,6 @@
   opacity: 0.6;
 }
 
-.goth-logo-link .arrow-left {
-  margin-right: 10px;
-}
-
 .goth-h-logo {
   fill: white;
 }

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -159,6 +159,7 @@ h1.district-map-title {
   cursor: pointer;
   align-items: center;
   justify-content: center;
+  text-decoration: none;
 }
 
 .district-details__eyebrow-link .gothamist-logo-mini {

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -501,3 +501,7 @@ h1.district-map-title {
   height: 22px;
   margin: 40px auto;
 }
+
+i.fab, i.fas {
+  font-size: 24px;
+}

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -49,7 +49,7 @@ main {
 .address-form__form {
   background-color: $lightgray;
   margin: 32px 16px;
-  padding: 18px 18px 33px 18px;
+  padding: 42px 18px 33px 18px;
 }
 .address-form__label {
   margin-bottom: 8px;

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -81,7 +81,10 @@ main {
   margin-bottom: 15px;
 
   &::placeholder {
-    color: #333;
+    opacity: 0.2;
+    font-size: 14px;
+    font-style: italic;
+    color: #333333;
   }
 }
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -72,9 +72,6 @@
     <header class="goth-header">
       <div class="goth-header__left">
         <a href="http://gothamist.com" class="goth-logo-link" target="_blank">
-          <svg class="arrow-left" xmlns="http://www.w3.org/2000/svg" width="9" height="16" viewBox="0 0 9 16">
-            <path fill="#FFF" fill-rule="evenodd" d="M8.816.222c.414.418 0 .784 0 .784L1.719 8.183 8.48 15.02s.352.429-.026.81c-.377.382-.905 0-.905 0L0 8.17 7.976.105s.427-.301.84.117z"/>
-          </svg>
           <svg class="goth-h-logo" xmlns="http://www.w3.org/2000/svg" width="119" height="27" viewBox="0 0 119 27">
             <path d="M.01 21.128h4.614V9.04H.01zM6.82 13.002h2.843v-1.896H6.82z"/>
             <path d="M5.684 19.232h4.831V12.46H5.684z"/>


### PR DESCRIPTION
- [x] please pre-check all email collectors so that the user only needs to enter their email (0111579)
- [x] update (on results) page the headline to say " Election & Assembly District: 000/000" (d18fce0)
- [x] (on the landing page) update the helper text in the form fields to match the styles in zeplin (italics, low opacity) (this looks correct on the results page, just not showing up on the landing page)
- [x] please check the <P> font size for the text, it looks too small on desktop, should b e font-size: 18 and line-height:27
- [x] there is a typo and some language changes in the "What you can do to improve turnout on block" area, can you please update the copy w/ the copy that is being used in the doc?
- [x] check the copy doc also for the "Get email updates" that has new copy
- [x] remove the carat in the brand header
- [x] increase font-size of share icons to 24px, but please keep the spacing btwn each icon the same
- [x] link the eyebrow to the main page please
- [x] (results page) add the missing # (total # of districts) to the description "Comparatively, your district ranked X out of the 2016..."
- [x] (on landing page) Check subhead copy, it changed to, "Voter turnout varies dramatically from one block to another in New York City. Enter your address and email below to find out if your neighbors vote—and how to get them to the polls if they don't."
    - [x] and remove "Enter your address + email below" (this was updated in zeplin)
